### PR TITLE
add policy in Rego

### DIFF
--- a/docs/cloud_compute/policy_samples.mdx
+++ b/docs/cloud_compute/policy_samples.mdx
@@ -155,7 +155,7 @@ Namespace object not supported in Prisma Cloud IaC
 </Tabs>
 
 
-## KubeCTL exec is not allowed
+## kubectl exec is not allowed
 
 <Tabs
 defaultValue={typeof window !== 'undefined' && localStorage.getItem('defaultLanguage') ? localStorage.getItem('defaultLanguage') : 'rego'}

--- a/docs/cloud_compute/policy_samples.mdx
+++ b/docs/cloud_compute/policy_samples.mdx
@@ -155,7 +155,7 @@ Namespace object not supported in Prisma Cloud IaC
 </Tabs>
 
 
-## kubectl exec is not allowed
+## "kubectl exec" is not allowed for group1 users
 
 <Tabs
 defaultValue={typeof window !== 'undefined' && localStorage.getItem('defaultLanguage') ? localStorage.getItem('defaultLanguage') : 'rego'}
@@ -170,6 +170,36 @@ match[{"msg": msg}] {
 	input.request.operation == "CONNECT"
 	input.request.userInfo.groups[_] == "group1"
 	msg := "It's not allowed for group1 users to exec into a pod"
+}
+```
+
+</TabItem>
+
+</Tabs>
+
+
+## Audit all kubectl CONNECT operations
+
+<Tabs
+defaultValue={typeof window !== 'undefined' && localStorage.getItem('defaultLanguage') ? localStorage.getItem('defaultLanguage') : 'rego'}
+values={[
+{ label: 'Rego', value: 'rego', },
+]
+}>
+<TabItem value="rego">
+
+```bash
+match[{"msg": msg}] {
+  input.request.operation == "CONNECT"
+  input.request.resource.resource == "pods"
+  exec_or_attach(input.request.subResource)
+  msg := "Exec or attach to a pod"
+}
+exec_or_attach(v) {
+  v == "exec"
+}
+exec_or_attach(v) {
+  v == "attach"
 }
 ```
 

--- a/docs/cloud_compute/policy_samples.mdx
+++ b/docs/cloud_compute/policy_samples.mdx
@@ -90,7 +90,7 @@ $.spec.template.spec.containers[*].ports[*].containerPort any equals 80
 </TabItem>
 </Tabs>
 
-## Deny Privilaged Pod
+## Deny Privileged Pod
 
 <Tabs
 defaultValue={typeof window !== 'undefined' && localStorage.getItem('defaultLanguage') ? localStorage.getItem('defaultLanguage') : 'rego'}
@@ -152,4 +152,27 @@ Namespace object not supported in Prisma Cloud IaC
 ```
 
 </TabItem>
+</Tabs>
+
+
+## KubeCTL exec is not allowed
+
+<Tabs
+defaultValue={typeof window !== 'undefined' && localStorage.getItem('defaultLanguage') ? localStorage.getItem('defaultLanguage') : 'rego'}
+values={[
+{ label: 'Rego', value: 'rego', },
+]
+}>
+<TabItem value="rego">
+
+```bash
+match[{"msg": msg}] {
+	input.request.operation == "CONNECT"
+	input.request.userInfo.groups[_] == "group1"
+	msg := "It's not allowed for group1 users to exec into a pod"
+}
+```
+
+</TabItem>
+
 </Tabs>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
That 'kubectl exec' audit rego query example is dependent on a bug (25644) that doesn't properly catch 'execs', but fix is being worked on right now.
The PR can be pulled on till then if necessary, but will apply as an example nontheless.

There's only a rego example for that, not a jquery yet.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes if appropriate.
- [ x ] All new and existing tests passed.
