### PR TITLE
fix missing rego/json toggles

### DIFF
--- a/docs/cloud_compute/policy_samples.mdx
+++ b/docs/cloud_compute/policy_samples.mdx
@@ -161,6 +161,7 @@ Namespace object not supported in Prisma Cloud IaC
 defaultValue={typeof window !== 'undefined' && localStorage.getItem('defaultLanguage') ? localStorage.getItem('defaultLanguage') : 'rego'}
 values={[
 { label: 'Rego', value: 'rego', },
+{ label: 'JSON', value: 'json', },
 ]
 }>
 <TabItem value="rego">
@@ -191,6 +192,7 @@ CONNECT operations not supported in Prisma Cloud IaC, as those are runtime audit
 defaultValue={typeof window !== 'undefined' && localStorage.getItem('defaultLanguage') ? localStorage.getItem('defaultLanguage') : 'rego'}
 values={[
 { label: 'Rego', value: 'rego', },
+{ label: 'JSON', value: 'json', },
 ]
 }>
 <TabItem value="rego">
@@ -228,6 +230,7 @@ CONNECT operations not supported in Prisma Cloud IaC, as those are runtime audit
 defaultValue={typeof window !== 'undefined' && localStorage.getItem('defaultLanguage') ? localStorage.getItem('defaultLanguage') : 'rego'}
 values={[
 { label: 'Rego', value: 'rego', },
+{ label: 'JSON', value: 'json', },
 ]
 }>
 <TabItem value="rego">


### PR DESCRIPTION
## Description

connected to #50 this somehow skipped a couple of the json/rego toggles. it's now there and double checked, not one-checked.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
