### PR TITLE
Add IAM example regarding S3 and Lambdas

### DIFF
--- a/docs/cloud/cspm/rql/aws/iam_aws.md
+++ b/docs/cloud/cspm/rql/aws/iam_aws.md
@@ -33,6 +33,6 @@ config from iam where action.name IN ( 'iam:CreateUser' , 'iam:AttachGroupPolicy
 
 ### Identify Lambda functions that can delete S3 buckets
 
-```
+```bash
 config from iam where dest.cloud.service.name = 's3' AND action.name IN ( 's3:deletebucket') and source.cloud.service.name = 'lambda'
 ```

--- a/docs/cloud/cspm/rql/aws/iam_aws.md
+++ b/docs/cloud/cspm/rql/aws/iam_aws.md
@@ -30,3 +30,9 @@ grantedby.cloud.policy.name = 'AdministratorAccess'
 ```bash
 config from iam where action.name IN ( 'iam:CreateUser' , 'iam:AttachGroupPolicy' , 'iam:UpdateUser' , 'iam:DeleteVirtualMFADevice' )
 ```
+
+### Identify Lambda functions that can delete S3 buckets
+
+```
+config from iam where dest.cloud.service.name = 's3' AND action.name IN ( 's3:deletebucket') and source.cloud.service.name = 'lambda'
+```


### PR DESCRIPTION
## Description

This PR will add another example for IAM RQL in the context of AWS. The query being added shows the Lambda functions capable of deleting S3 buckets.

## Motivation and Context

This change helps expand the IAM-AWS example with an example that in the world may be appropriate to search for. This query has also been one of the more boiler plate examples from the product team and thus us a good candidate to be persisted here.

## How Has This Been Tested?

Ran it in the investigate tab, got results!

## Screenshots (if appropriate)

Nope, none should be needed for this.

## Types of changes

- New Content

## Checklist

- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes if appropriate.
- [ x] All new and existing tests passed.
