### PR TITLE
Added new S3 example for non-onboarded accounts

### DIFF
--- a/docs/cloud/cspm/rql/aws/aws_s3.md
+++ b/docs/cloud/cspm/rql/aws/aws_s3.md
@@ -36,3 +36,9 @@ and tagSets.DataClassification != Public"
 ```bash
 config from cloud.resource where api.name = 'aws-cloudfront-list-distributions' as X; config from cloud.resource where api.name = 'aws-s3api-get-bucket-acl' as Y; filter '$.X.origins.items[*].id contains $.Y.bucketName'; show Y;
 ```
+
+### S3 buckets that have PUT actions with ALLOW effects to external AWS accounts (that are not monitored by Prisma Cloud)
+
+```bash
+config from cloud.resource where api.name='aws-s3api-get-bucket-acl' AND json.rule = policy.Statement[*].Principal.AWS[*] exists and _AWSCloudAccount.isRedLockMonitored(policy.Statement[*].Principal.AWS[*]) is false and policy.Statement[?(@.Effect=='Allow')].Action any equal s3:PutObject
+```


### PR DESCRIPTION
## Description

Added RQL example for S3 buckets that have PUT actions with ALLOW effects to external AWS accounts (that are not monitored by Prisma Cloud)

## Motivation and Context

## How Has This Been Tested?

Tested for false positives, other actions, deny, and for external vs Prisma Cloud monitored accounts

## Screenshots (if appropriate)

## Types of changes

- new example

## Checklist

- [x ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes if appropriate.
- [x ] All new and existing tests passed.
