### PR TITLE
add omitted text in 2 CSPM cloud APIs. Remove references to old CWPP …

### DIFF
--- a/docs/cloud/home.md
+++ b/docs/cloud/home.md
@@ -17,6 +17,7 @@ keywords:
 Prisma Cloud is a cloud native security platform that provides comprehensive visibility, threat prevention, compliance assurance and data protection consistently across the entire lifecycle of software and infrastructure delivery for an organization in hybrid, multi-cloud environments. 
 
 This site describes the APIs you can use to automate your usage of the following Prisma Cloud modules:
+
 * **Cloud Security Posture Management (CSPM)**
   Leverages data from public service providers to deliver continuous visibility, security policy
   compliance and threat detection across cloud resources, users, data and applications. This
@@ -28,13 +29,10 @@ This site describes the APIs you can use to automate your usage of the following
 * **Cloud Workload Protection (CWPP)**
   Helps secure cloud native applications across the application lifecycle, defined by the
   requirement to protect hosts (VMs), containers and serverless from a single console.
-  (API documentation is coming soon. For now, please see the
-  [Prisma Cloud Compute API documentation](https://cdn.twistlock.com/docs/api/twistlock_api.html).)
 
 
 For information about Prisma Cloud beyond its APIs, such as administration and policy management,
 see the [Prisma Cloud administration documentation](https://docs.paloaltonetworks.com/prisma/prisma-cloud.html).
-
 
 :::info
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -117,11 +117,6 @@ module.exports = {
         'cloud/cwpp/policy_samples',
         'cloud/cwpp/twistcli_gs',
         'cloud/cwpp/custom_compliance_samples',
-        {
-          type: 'link',
-          label: "Compute API Reference",
-          href: 'https://cdn.twistlock.com/docs/api/twistlock_api.html',
-        },
         'cloud/cwpp/cwpp_postman_collection',
         {
           type: 'category',

--- a/static/oas/cspm/CloudAccounts.yaml
+++ b/static/oas/cspm/CloudAccounts.yaml
@@ -1435,9 +1435,10 @@ paths:
       - Cloud Accounts
   /cloud/gcp/parent/{parent_id}/children:
     post:
-      description: For GCP only. List all the children, both folder resources and
-        project resources, of the given parent. A parent can be an organization resource
-        or a folder resource.
+      description: "For GCP only. List all the children, both folder resources and\
+        \ project resources, of the given parent. A parent can be an organization\
+        \ resource or a folder resource.  \r\n\r\nThe request body parameter is the\
+        \ content of the Service Account Key (JSON) file, which is required.\n"
       operationId: get-list-of-children-under-parent
       parameters:
       - description: GCP parent resource ID
@@ -1503,8 +1504,10 @@ paths:
       - Cloud Accounts
   /cloud/{cloud_type}/parent/{parent_id}/folders:
     post:
-      description: For GCP only. List all the child folders of the given parent. A
-        parent can be an organization resource or a folder resource.
+      description: "For GCP only. List all the child folders of the given parent.\
+        \ A parent can be an organization resource or a folder resource.  \r\n\r\n\
+        The request body parameter is the content of the Service Account Key (JSON)\
+        \ file, which is required.\n"
       operationId: get-list-of-folders-under-parent
       parameters:
       - description: Cloud type

--- a/static/oas/cspm/dist/CloudAccounts.json
+++ b/static/oas/cspm/dist/CloudAccounts.json
@@ -1387,7 +1387,7 @@
     },
     "/cloud/gcp/parent/{parent_id}/children": {
       "post": {
-        "description": "For GCP only. List all the children, both folder resources and project resources, of the given parent. A parent can be an organization resource or a folder resource.",
+        "description": "For GCP only. List all the children, both folder resources and project resources, of the given parent. A parent can be an organization resource or a folder resource.  \r\n\r\nThe request body parameter is the content of the Service Account Key (JSON) file, which is required.\n",
         "operationId": "get-list-of-children-under-parent",
         "parameters": [
           {
@@ -1476,7 +1476,7 @@
     },
     "/cloud/{cloud_type}/parent/{parent_id}/folders": {
       "post": {
-        "description": "For GCP only. List all the child folders of the given parent. A parent can be an organization resource or a folder resource.",
+        "description": "For GCP only. List all the child folders of the given parent. A parent can be an organization resource or a folder resource.  \r\n\r\nThe request body parameter is the content of the Service Account Key (JSON) file, which is required.\n",
         "operationId": "get-list-of-folders-under-parent",
         "parameters": [
           {


### PR DESCRIPTION
CSPM and CWPP

## Description

1. In cspm API reference: add back some omitted text to 2 cloud APIs
2. In docs: Remove references to old cwpp API doc in (a) sidebar and (b) welcome page

## Motivation and Context

1. Omitted text should have always been there
2. Confirmed with Matangi that we should remove the links to the old CWPP API reference now that CWPP APIs are part of pan.dev

## How Has This Been Tested?

locally with yarn

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- Bug fix 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
