### PR TITLE
PCSUP-4976 Fix TimeRangeConfig example

### DIFF
--- a/api/cloud/api-time-range-model.md
+++ b/api/cloud/api-time-range-model.md
@@ -2,7 +2,7 @@
 
 id: api-time-range-model
 
-title: Prisma Cloud API Time Range Model
+title: Prisma Cloud CSPM API Time Range Model
 
 sidebar_label: Time Range Model
 
@@ -10,9 +10,15 @@ hide_table_of_contents: false
 
 ---
 
-## Time Range Model for Most Prisma Cloud APIs
+Some Prisma Cloud Cloud Security Posture Management (CSPM) API request or response objects include a time range model. Depending on the endpoint, this model can describe a time range in different ways. The examples below illustrate the different uses of this model.
 
-​The following time model descriptions apply to all public Prisma Cloud REST APIs that use a time range model except for compliance report, compliance posture, asset inventory, and alert dismissal APIs.
+* [Time Range Model for Most CSPM Endpoints](#time-range-model-for-most-cspm-endpoints)
+* [Compliance Report, Posture, and Asset Inventory Time Range Model](#compliance-report-posture-and-asset-inventory-time-range-model)
+* [Alert Dismissal Time Range Model](#alert-dismissal-time-range-model)
+
+## Time Range Model for Most CSPM Endpoints
+
+​The following time range model descriptions apply to all public CSPM endpoints that use a time range model except for compliance report, compliance posture, asset inventory, and alert dismissal endpoints.
 
 * [Absolute  time](#absolute-time)
 * [Relative  time](#relative-time)
@@ -20,9 +26,9 @@ hide_table_of_contents: false
 
 ### Absolute Time
 
-Time type **absolute** enables you to  specify an exact Unix timestamp (milliseconds) for both start time and end time. The **Absolute  Time** example below shows the start time and end time timestamps. This is used when the start and end unix timestamps are available (in ms). In the JSON example the **startTime** is 1504448933000 and the **endTime** is 1504794533000.
+With time type **absolute**, you specify Unix timestamps in milliseconds to define the start and end of your time range. The JSON example below shows a **startTime** timestamp of 1504448933000 and an **endTime** timestamp of 1504794533000.
 
-```
+```json
  {
     "timeRange": {
          "type": "absolute",
@@ -34,14 +40,14 @@ Time type **absolute** enables you to  specify an exact Unix timestamp (millisec
 }
 ```
 
-For equivalent APIs with GET methods and query parameters, the time range query parameters make up a query string that is appended
+For equivalent endpoints with GET methods and query parameters, the time range query parameters make up a query string that appends
 to the endpoint URL. An example of a query string is: ``&timeType=absolute&startTime=1504448933000&endTime=1504794533000``
 
 ### Relative Time
 
-Time type **relative** defines a window of time between a given  point of time in the past until now. You should specify both an amount and a time unit for time type **relative**.  The **Relative  Time** example below shows JSON with the relative value of 3, and the unit of days. Valid values for **unit** are **hour**, **day**, **week**, **month**, and **year**.
+Time type **relative** defines a window of time from a given point of time in the past until now. Provide both an amount and a time unit.  The JSON example below specifies the past three days. Valid values for **unit** are **hour**, **day**, **week**, **month**, and **year**.
 
-```
+```json
 {
     "timeRange": {
         "type": "relative",
@@ -53,57 +59,49 @@ Time type **relative** defines a window of time between a given  point of time i
 }
 ```
 
-For equivalent APIs with GET methods and query parameters, the time range query parameters make up a query string that is appended
+For equivalent endpoints with GET methods and query parameters, the time range query parameters make up a query string that is appends
 to the endpoint URL. An example of a query string is: ``&timeType=relative&timeAmount=3&timeUnit=day``
 
 ### Time To Now
 
-Like time type **relative**, time type **to_now** represents a windows of time until now, but the time window starting point is the start of the current year, month, week, or day, depending on the **unit** you specify. In addition, a unit of **login** indicates a period from the time of your last login until now, and a unit of **epoch** indicates a period from the time of your account onboarding until now. In the **Time  To  Now** example below, the period of time starts at your last login. Valid values for **unit** are:
+Like [time type **relative**](#relative-time), time type **to_now** represents a window of time until now, but the time window starting point is the start of the current year, month, week, or day. The unit of time depends on the **value** you specify. In addition, a value of **login** indicates a range from the time of your last login until now, and a value of **epoch** indicates a range from the time of your account on-boarding until now. In the example below, the time range starts from your last login. Valid values for **value** are:
 
-* **login** - from last login
-* **epoch** - from account onboarding
-* **day** - from beginning of the day
-* **week** - from beginning of the week
-* **month** - from beginning of the month
-* **year** - from beginning of the year
+* **login**: From last login
+* **epoch**: From account on-boarding
+* **day**: From beginning of the day
+* **week**: From beginning of the week
+* **month**: From beginning of the month
+* **year**: From beginning of the year
 
-```
+```json
 {
     "timeRange": {
         "type": "to_now",
-        "value": {
-            "unit": "login"
-        }
+        "value": "login"
     }
 }
 ```
 
-​For equivalent APIs with GET methods and query parameters, the time range query parameters make up a query string that is appended
+​For equivalent endpoints with GET methods and query parameters, the time range query parameters make up a query string that appends
 to the endpoint URL. An example of a query string is: ``&timeType=to_now&timeUnit=login``
 
-## Compliance Report, Posture, and Asset Inventory Time Range Model
+## Compliance and Asset Inventory Time Range Model
 
-The following time model descriptions apply only to compliance report, compliance posture, asset inventory, and resource (asset) explorer APIs.
+The following time range model descriptions apply only to the endpoints listed below:
 
-- [Time Range Model for Most Prisma Cloud APIs](#time-range-model-for-most-prisma-cloud-apis)
-  - [Absolute Time](#absolute-time)
-  - [Relative Time](#relative-time)
-  - [Time To Now](#time-to-now)
-- [Compliance Report, Posture, and Asset Inventory Time Range Model](#compliance-report-posture-and-asset-inventory-time-range-model)
-  - [Absolute Time for Compliance and Asset Inventory](#absolute-time-for-compliance-and-asset-inventory)
-  - [Relative Time for Compliance and Asset Inventory](#relative-time-for-compliance-and-asset-inventory)
-  - [Time To Now for Compliance and Asset Inventory](#time-to-now-for-compliance-and-asset-inventory)
-- [Alert Dismissal Time Range Model](#alert-dismissal-time-range-model)
-  - [Absolute Time for Alert Dismissal](#absolute-time-for-alert-dismissal)
-  - [Relative Time for Alert Dismissal](#relative-time-for-alert-dismissal)
+* Compliance:
+  * [Compliance posture](/api/cloud/cspm/compliance-posture)
+  * [Compliance reports](/api/cloud/cspm/reports)
 
-For all APIs that use these time range models, when you send a request body (POST / PUT), you represent the time range models as objects. When you're sending time ranges through query parameters (GET), though, you use a flattened version of the model.
+* Asset Inventory:  
+  * [Asset inventory](/api/cloud/cspm/asset-inventory)
+  * [Resource (asset) explorer](/api/cloud/cspm/resource-explorer)
 
 ### Absolute Time for Compliance and Asset Inventory
 
-​Time type **absolute** enables you to  specify an exact Unix timestamp (milliseconds) just for an end time. The resulting time window is one with a start time equal to the time of account on-boarding and an end time equal to the **endTime** you specified. In the JSON example below, the value for **endTime** is 1504794533000.
+​For time type **absolute**, specify a Unix timestamp in milliseconds for just an end time. The resulting time range has a start time equal to the time of your account on-boarding and an end time equal to the **endTime** you specified. The JSON example below specifies a time range from the time of your account on-boarding until the Unix timestamp 1504794533000 in milliseconds.
 
-```
+```json
  {
     "timeRange": {
          "type": "absolute",
@@ -115,14 +113,14 @@ For all APIs that use these time range models, when you send a request body (POS
 
 ```
 
-For equivalent APIs with GET methods and query parameters, the time range query parameters make up a query string that is appended
+For equivalent endpoints with GET methods and query parameters, the time range query parameters make up a query string that appends
 to the endpoint URL. An example of a query string is: ``&timeType=absolute&startTime=1504448933000&endTime=1504794533000``
 
 ### Relative Time for Compliance and Asset Inventory
 
-Time type **relative** enables you to describe a  point in time relative to the present. You should specify both an amount and a time unit for time type **relative**.  For example, an amount of 3 with a unit of day designates three days ago. The relative window of time for compliance report, compliance posture, and asset inventory APIs is from the time of account on-boarding until the specified relative point in time. In the JSON example, the time window is from account on-boarding time until three days ago. The various units of time that's supported are **hour**, **day**, **week**, **month**, and **year**.
+Time type **relative** defines a window of time from a given point in the past until now. Specify both an amount and a time unit. For example, an amount of 3 with a unit of day designates three days ago. The relative time range for compliance and asset inventory endpoints is from the time of account on-boarding until the specified relative point in time. In the following JSON example, the time window is from account on-boarding time until three days ago. Valid values for **unit** are **hour**, **day**, **week**, **month**, and **year**.
 
-```
+```json
 {
     "timeRange": {
         "type": "relative",
@@ -134,25 +132,22 @@ Time type **relative** enables you to describe a  point in time relative to the 
 }
 ```
 
-For equivalent APIs with GET methods and query parameters, the time range query parameters make up a query string that is appended
-to the endpoint URL. An example of a query string is: ``&timeType=relative&timeAmount=3&timeUnit=day``
+For equivalent endpoints with GET methods and query parameters, the time range query parameters make up a query string that appends to the endpoint URL. An example of a query string is: ``&timeType=relative&timeAmount=3&timeUnit=day``
 
 ### Time To Now for Compliance and Asset Inventory
 
-For time type **to_now**, the only valid value for **unit** is **epoch**, so **to_now** defines a time window between the  time of account on-boarding and the current time.
+For time type **to_now**, the only valid value for **value** is **epoch**, so **to_now** defines a time window between the time of account on-boarding and the current time.
 
-```
+```json
 {
     "timeRange": {
         "type": "to_now",
-        "value": {
-            "unit": "epoch"
-        }
+        "value": "epoch"
     }
 }
 ```
 
-For equivalent APIs with GET methods and query parameters, the time range query parameters make up a query string that is appended
+For equivalent endpoints with GET methods and query parameters, the time range query parameters make up a query string that appends
 to the endpoint URL. An example of a query string is: ``&timeType=to_now&timeUnit=epoch``
 
 ## Alert Dismissal Time Range Model
@@ -164,9 +159,9 @@ The time range model for alert dismissal is special because it denotes a point o
 
 ### Absolute Time for Alert Dismissal
 
-Time type **absolute** enables you to  specify an exact Unix timestamp (milliseconds) just for an **endTime**. The **endTime** identifies a future point in time. In the JSON example below, **endTime** is set to 1504794533000.
+With time type **absolute**,  specify a Unix timestamp in milliseconds for just an **endTime**. The **endTime** identifies a future point in time. The JSON example below describes a future dismissal time of timestamp 1504794533000.
 
-```
+```json
 {
     "timeRange": {
         "type": "absolute",
@@ -179,9 +174,9 @@ Time type **absolute** enables you to  specify an exact Unix timestamp (millisec
 
 ### Relative Time for Alert Dismissal
 
-Time type **relative** enables you to describe a future point in time in relative terms. You should specify both an amount and a time unit for time type **relative**.  For example, an **amount** of 3 with a **unit** of day means three days from now. The values for **unit** can be **hour**, **day**, **week**, **month**, or **year**.
+Time type **relative** describes a future point in time in relative terms. Specify both an amount and a time unit.  For example, an **amount** of 3 with a **unit** of **day** means three days from now. The values for **unit** can be **hour**, **day**, **week**, **month**, or **year**.
 
-```
+```json
 {
     "timeRange": {
         "type": "relative",


### PR DESCRIPTION
## Description

PCSUP-4976: Time to now model format is incorrect

## Motivation and Context

Sample is incorrect. Text could be improved.

## How Has This Been Tested?

Tested locally.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

- Bug fix 

## Checklist


- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
