### PR TITLE
Search doesn't require admin role. Plus some minor term updates

### DIFF
--- a/static/oas/cspm/Search.yaml
+++ b/static/oas/cspm/Search.yaml
@@ -1139,12 +1139,11 @@ openapi: 3.0.0
 paths:
   /search/config:
     post:
-      description: "Returns the results of an RQL Config query. With Config queries,\
+      description: "Returns the results of an RQL config query. With config queries,\
         \ you can retrieve resource information, identify misconfigurations, gain\
         \ operational insights, and uncover policy and compliance violations.  \r\n\
-        \r\nThis API requires Prisma Cloud system administrator role access.\n\n###\
-        \ Download Config Search CSV \nIn addition to performing a config search,\
-        \ this API can perform the config \nsearch and download the results as a CSV\
+        \r\n### Download Config Search CSV \nIn addition to performing a config search,\
+        \ this endpoint can perform the config \nsearch and download the results as a CSV\
         \ file. To download the config search CSV, \nadd the request HTTP header **Accept:\
         \ text/csv**.\n\nAn example request body is:\n```\n{\n  \"query\":\"config\
         \ where api.name = 'aws-iam-get-account-summary' \",\n  \"timeRange\":{\n\
@@ -1179,8 +1178,8 @@ paths:
   /search:
     post:
       description: "Perform a search against flow logs with an RQL query.  \r\n\r\n\
-        This API ignores the body param **default**. \n\n### Download Network Search\
-        \ CSV \nIn addition to performing a network search, this API can perform the\
+        This endpoint ignores the body param **default**. \n\n### Download Network Search\
+        \ CSV \nIn addition to performing a network search, this endpoint can perform the\
         \ network \nsearch and download the results as a CSV file. To download the\
         \ network search CSV, \nadd the request HTTP header **Accept: text/csv**.\n\
         \nAn example request body is:\n```\n{\n  \"cloudType\": \"\",\n  \"id\":\"\

--- a/static/oas/cspm/SearchManager.yaml
+++ b/static/oas/cspm/SearchManager.yaml
@@ -1,11 +1,11 @@
 components:
+  requestBodies: {}
   securitySchemes:
     x-redlock-auth:
       description: JWT Based Authentication
       in: header
       name: x-redlock-auth
       type: apiKey
-  requestBodies: {}
   schemas:
     AbsoluteTimeRangeConfigModel:
       allOf:
@@ -291,12 +291,6 @@ info:
   title: Prisma Cloud Search Manager API Overview
   version: Latest
 openapi: 3.0.0
-servers:
-- url: https://api.prismacloud.io
-tags:
-- description: The APIs to save a search and manage your saved searches are listed
-    below.
-  name: Search Manager
 paths:
   /search/history:
     get:
@@ -367,7 +361,7 @@ paths:
         \ the saved search. A best \npractice is to copy data from the results of\
         \ a search history, update the \ndata as necessary, and set the **saved**\
         \ parameter to **true**.\n\nThis API requires Prisma Cloud system administrator\
-        \ role access.\n"
+        \ role access if you don't own the search with the given search ID.\n"
       operationId: search-history-save
       parameters:
       - description: Search ID
@@ -430,3 +424,9 @@ paths:
       summary: Delete Saved Search Query
       tags:
       - Search Manager
+servers:
+- url: https://api.prismacloud.io
+tags:
+- description: The APIs to save a search and manage your saved searches are listed
+    below.
+  name: Search Manager

--- a/static/oas/cspm/dist/Search.json
+++ b/static/oas/cspm/dist/Search.json
@@ -1005,7 +1005,7 @@
   "paths": {
     "/search/config": {
       "post": {
-        "description": "Returns the results of an RQL Config query. With Config queries, you can retrieve resource information, identify misconfigurations, gain operational insights, and uncover policy and compliance violations.  \r\n\r\nThis API requires Prisma Cloud system administrator role access.\n\n### Download Config Search CSV \nIn addition to performing a config search, this API can perform the config \nsearch and download the results as a CSV file. To download the config search CSV, \nadd the request HTTP header **Accept: text/csv**.\n\nAn example request body is:\n```\n{\n  \"query\":\"config where api.name = 'aws-iam-get-account-summary' \",\n  \"timeRange\":{\n     \"type\":\"relative\",\n     \"value\":{\n        \"unit\":\"hour\",\n        \"amount\":24\n     }\n  }\n}\n```\n",
+        "description": "Returns the results of an RQL config query. With config queries, you can retrieve resource information, identify misconfigurations, gain operational insights, and uncover policy and compliance violations.  \r\n\r\n### Download Config Search CSV \nIn addition to performing a config search, this endpoint can perform the config \nsearch and download the results as a CSV file. To download the config search CSV, \nadd the request HTTP header **Accept: text/csv**.\n\nAn example request body is:\n```\n{\n  \"query\":\"config where api.name = 'aws-iam-get-account-summary' \",\n  \"timeRange\":{\n     \"type\":\"relative\",\n     \"value\":{\n        \"unit\":\"hour\",\n        \"amount\":24\n     }\n  }\n}\n```\n",
         "operationId": "search-config",
         "requestBody": {
           "content": {
@@ -1050,7 +1050,7 @@
     },
     "/search": {
       "post": {
-        "description": "Perform a search against flow logs with an RQL query.  \r\n\r\nThis API ignores the body param **default**. \n\n### Download Network Search CSV \nIn addition to performing a network search, this API can perform the network \nsearch and download the results as a CSV file. To download the network search CSV, \nadd the request HTTP header **Accept: text/csv**.\n\nAn example request body is:\n```\n{\n  \"cloudType\": \"\",\n  \"id\":\"\",\n  \"name\":\"\",\n  \"description:\"\",\n  \"saved\":false,\n  \"default\":false,\n  \"query\": \"\",\n    \"timeRange\": {\n      \"type\": \"\",\n      \"value\": \"\"\n    }\n}\n```\n",
+        "description": "Perform a search against flow logs with an RQL query.  \r\n\r\nThis endpoint ignores the body param **default**. \n\n### Download Network Search CSV \nIn addition to performing a network search, this endpoint can perform the network \nsearch and download the results as a CSV file. To download the network search CSV, \nadd the request HTTP header **Accept: text/csv**.\n\nAn example request body is:\n```\n{\n  \"cloudType\": \"\",\n  \"id\":\"\",\n  \"name\":\"\",\n  \"description:\"\",\n  \"saved\":false,\n  \"default\":false,\n  \"query\": \"\",\n    \"timeRange\": {\n      \"type\": \"\",\n      \"value\": \"\"\n    }\n}\n```\n",
         "operationId": "search-network",
         "requestBody": {
           "content": {

--- a/static/oas/cspm/dist/SearchManager.json
+++ b/static/oas/cspm/dist/SearchManager.json
@@ -1,5 +1,6 @@
 {
   "components": {
+    "requestBodies": {},
     "securitySchemes": {
       "x-redlock-auth": {
         "description": "JWT Based Authentication",
@@ -8,7 +9,6 @@
         "type": "apiKey"
       }
     },
-    "requestBodies": {},
     "schemas": {
       "AbsoluteTimeRangeConfigModel": {
         "allOf": [
@@ -282,13 +282,6 @@
     "version": "Latest"
   },
   "openapi": "3.0.0",
-  "servers": [{ "url": "https://api.prismacloud.io" }],
-  "tags": [
-    {
-      "description": "The APIs to save a search and manage your saved searches are listed below.",
-      "name": "Search Manager"
-    }
-  ],
   "paths": {
     "/search/history": {
       "get": {
@@ -378,7 +371,7 @@
         ]
       },
       "post": {
-        "description": "Saves a search query to the **Saved Searches** list under the specified ID.  \r\n\r\nRequired parameters include the search ID, the RQL query, the flag that \nmarks this search as saved, and a unique name for the saved search. A best \npractice is to copy data from the results of a search history, update the \ndata as necessary, and set the **saved** parameter to **true**.\n\nThis API requires Prisma Cloud system administrator role access.\n",
+        "description": "Saves a search query to the **Saved Searches** list under the specified ID.  \r\n\r\nRequired parameters include the search ID, the RQL query, the flag that \nmarks this search as saved, and a unique name for the saved search. A best \npractice is to copy data from the results of a search history, update the \ndata as necessary, and set the **saved** parameter to **true**.\n\nThis API requires Prisma Cloud system administrator role access if you don't own the search with the given search ID.\n",
         "operationId": "search-history-save",
         "parameters": [
           {
@@ -466,5 +459,12 @@
         ]
       }
     }
-  }
+  },
+  "servers": [{ "url": "https://api.prismacloud.io" }],
+  "tags": [
+    {
+      "description": "The APIs to save a search and manage your saved searches are listed below.",
+      "name": "Search Manager"
+    }
+  ]
 }


### PR DESCRIPTION
## Description

The description for POST /search/config says that the endpoint requires sys admin role, but there is no such requirement.
The description for POST /search/history/{id} also needs to be updated.

## Motivation and Context

Statements about sys admin role requirements are incorrect.

## How Has This Been Tested?

Tested locally.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
