### PR TITLE
Update contributing guide to point to repo name

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -51,14 +51,14 @@ Most of the information in this section can be found in [GitHub Help](https://he
 4. Clone your fork to your local machine using the following command:
 
 ```bash
-git clone https://github.com/{your user name}/{the developer site repo}.git
+git clone https://github.com/{your user name}/prisma.pan.dev.git
 ```
 
 Next, create a reference to the root repository by entering these commands:
 
 ```bash
 cd <your cloned repo folder>
-git remote add upstream https://github.com/PaloAltoNetworks/{the developer site repo}.git // optionally use the SSH repo URL
+git remote add upstream https://github.com/PaloAltoNetworks/prisma.pan.dev.git // optionally use the SSH repo URL
 git fetch upstream
 ```
 


### PR DESCRIPTION
## Description

Update the documentation to point at the name of the repo.
## Motivation and Context

The current contributing guide does not say the name of the repo. The github link at the top of the docs links to the PaloAltoNetworks group, so you then have to search the repos to find what the name is.

## How Has This Been Tested?

N/A, just documentation.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
