### PR TITLE
Remove-basic-auth-content-from-saas-api

### DIFF
--- a/docs/cloud/cwpp/access-api-saas.md
+++ b/docs/cloud/cwpp/access-api-saas.md
@@ -15,28 +15,6 @@ By default, the Prisma Cloud System Admin role is mapped to the Prisma Cloud Com
 
 For automated workflows, you'll want to provision a service account with the minimum required permissions.
 
-
-## Accessing the API using Basic authentication
-
-Get your Compute Console's address and then use basic auth to access the API.
-
-1. Get the path to your Console.
-
-   1. Go to **Compute > Manage > System > Utilities**.
-
-   1. Under **Path to Console**, click **Copy**.
-
-1. Access an API endpoint.
-
-   In this example, retrieve the rules in your compliance policy.
-   The Auditor role has permission to see this data.
-
-   ```
-   $ curl \
-   -u <PRISMA_CLOUD_USER> \
-   https://<CONSOLE>/api/v1/policies/compliance/container
-   ```
-
 ## Accessing the API using token authentication
 
 Get your Compute Console's address, retrieve an token, then use the token to access the API.


### PR DESCRIPTION
## Description

Removed the content about the basic authentication from the SaaS API page.

## Motivation and Context

The basic authentication is not the recommended method to access SaaS APIs. Only access token method works. This is done after discussions with Kade and Eric (from Sony).

## Types of changes
- Bug fix to remove the unsupported method to access SaaS API.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
