### PR TITLE
Update twistcli_gs.md

### DIFF
--- a/docs/cloud/cwpp/twistcli_gs.md
+++ b/docs/cloud/cwpp/twistcli_gs.md
@@ -50,11 +50,12 @@ To specify an image to scan, use either the image ID, or repository name and tag
 # Return Value
 The exit code is 0 if `twistcli` finds no vulnerabilities or compliance issues. Otherwise, the exit code is 1.
 
-The criteria for passing or failing a scan can be refined with any of the following parameters: `--compliance-threshold`, `--vulnerability-threshold`, and `--only-fixed`.
+The criteria for passing or failing a scan can be refined with vulnerability and compliance rules configured via the console.
 
 >The twistcli utility returns exit code 1 for two reasons:
 > * It fails to run due to an error.
-> * The scan fails because the results exceed the thresholds specified with `--compliance-threshold`, `--vulnerability-threshold`, and `--only-fixed`.
+> * The scan fails because the results exceed the thresholds specified in the vulnerability or compliance rules.
+> 
 >Although the return value is ambiguous — you cannot determine the exact reason for the failure by just examining the return value — this setup supports automation. From an automation process perspective, you expect that the entire flow will work. If you scan an image, with or without a threshold, either it works or it does not work. If it fails, for whatever reason, you want to fail everything because there is a problem.
 
 ## Scan results


### PR DESCRIPTION
## Description

Remove old references to vulnerability and compliance threshold flags.

## Motivation and Context

Remove old references to vulnerability and compliance threshold flags as they are no longer present in twistcli. 20.04.163 release notes "Existing CI policies defined with twistcli parameters, such as --vulnerability-threshold, --compliance-threshold, etc, have been deprecated. All those parameters are now centrally defined in Console in a new dedicated CI policy page. If you try to pass these parameters to twistcli version 20.04.163, twistcli will exit with an error: Incorrect Usage: flag provided but not defined. When upgrading to 20.04, you must fix how twistcli is called in your pipeline (remove deprecated policy params) and re-implement your policy in Console’s new CI policy engine."

## How Has This Been Tested?

N/A

## Screenshots (if appropriate)

N/A

## Types of changes

Documentation update

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
